### PR TITLE
Add ACA CLI install scripts and docs for Early Access release

### DIFF
--- a/docs/early/aca-cli/README.md
+++ b/docs/early/aca-cli/README.md
@@ -1,0 +1,62 @@
+# ACA CLI
+
+Command-line interface for Azure Container Apps.
+
+## Prerequisites
+
+- **Azure CLI** (`az`) must be installed — [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
+- Run `az login` at least once before using `aca`. The CLI uses Azure CLI authentication.
+
+## Installation
+
+### Linux / macOS
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.sh | sh
+```
+
+To install a specific version:
+
+```sh
+ACA_VERSION=aca-cli-v0.1.0-early-access curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.sh | sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.ps1 | iex
+```
+
+To install a specific version:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.ps1))) -Version aca-cli-v0.1.0-early-access
+```
+
+## Uninstall
+
+### Linux / macOS
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.sh | sh -s -- --uninstall
+```
+
+### Windows (PowerShell)
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.ps1))) -Uninstall
+```
+
+## Supported Platforms
+
+| Platform | Architecture |
+|----------|-------------|
+| Linux    | x64, ARM64  |
+| macOS    | ARM64       |
+| Windows  | x64         |
+
+## Commands
+
+<!-- TODO: Add complete command tree -->
+
+Run `aca --help` to see all available commands.

--- a/docs/early/aca-cli/README.md
+++ b/docs/early/aca-cli/README.md
@@ -18,7 +18,7 @@ curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main
 To install a specific version:
 
 ```sh
-ACA_VERSION=aca-cli-v0.1.0-early-access curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | ACA_VERSION=aca-cli-v0.1.0-early-access sh
 ```
 
 ### Windows (PowerShell)

--- a/docs/early/aca-cli/README.md
+++ b/docs/early/aca-cli/README.md
@@ -1,6 +1,6 @@
-# ACA CLI
+# ACA CLI (Early Access)
 
-Command-line interface for Azure Container Apps.
+Command-line interface for Azure Container Apps Sandboxes (Early Access).
 
 ## Prerequisites
 
@@ -12,25 +12,25 @@ Command-line interface for Azure Container Apps.
 ### Linux / macOS
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
 ```
 
 To install a specific version:
 
 ```sh
-ACA_VERSION=aca-cli-v0.1.0-early-access curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.sh | sh
+ACA_VERSION=aca-cli-v0.1.0-early-access curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-irm https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.ps1 | iex
+irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1 | iex
 ```
 
 To install a specific version:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.ps1))) -Version aca-cli-v0.1.0-early-access
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Version aca-cli-v0.1.0-early-access
 ```
 
 ## Uninstall
@@ -38,13 +38,13 @@ To install a specific version:
 ### Linux / macOS
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.sh | sh -s -- --uninstall
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh -s -- --uninstall
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/aca-cli-preview/docs/early/aca-cli/install.ps1))) -Uninstall
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Uninstall
 ```
 
 ## Supported Platforms

--- a/docs/early/aca-cli/README.md
+++ b/docs/early/aca-cli/README.md
@@ -1,4 +1,4 @@
-# ACA CLI (Early Access)
+# ACA Sandboxes CLI (Early Access)
 
 Command-line interface for Azure Container Apps Sandboxes (Early Access).
 

--- a/docs/early/aca-cli/install.ps1
+++ b/docs/early/aca-cli/install.ps1
@@ -8,7 +8,7 @@ param(
 $ErrorActionPreference = "Stop"
 # TODO: Change branch to "main" once merged
 $Repo = "microsoft/azure-container-apps"
-$Branch = "aca-cli-preview"
+$Branch = "main"
 $BinaryName = "aca"
 
 function Uninstall-Aca {

--- a/docs/early/aca-cli/install.ps1
+++ b/docs/early/aca-cli/install.ps1
@@ -6,7 +6,6 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-# TODO: Change branch to "main" once merged
 $Repo = "microsoft/azure-container-apps"
 $Branch = "main"
 $BinaryName = "aca"

--- a/docs/early/aca-cli/install.ps1
+++ b/docs/early/aca-cli/install.ps1
@@ -1,0 +1,96 @@
+# ACA CLI Installer for Windows
+param(
+    [string]$Version = "latest",
+    [string]$InstallDir = "$env:USERPROFILE\.aca\bin",
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+# TODO: Change branch to "main" once merged
+$Repo = "microsoft/azure-container-apps"
+$Branch = "aca-cli-preview"
+$BinaryName = "aca"
+
+function Uninstall-Aca {
+    $AcaHome = Split-Path $InstallDir -Parent  # ~/.aca
+    $ExePath = Join-Path $InstallDir "$BinaryName.exe"
+    if (-not (Test-Path $ExePath) -and -not (Test-Path $AcaHome)) {
+        Write-Host "$BinaryName is not installed."
+        return
+    }
+
+    # Remove PATH entry
+    $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    if ($UserPath -like "*$InstallDir*") {
+        $NewPath = ($UserPath -split ';' | Where-Object { $_ -ne $InstallDir }) -join ';'
+        [Environment]::SetEnvironmentVariable("PATH", $NewPath, "User")
+        Write-Host "Removed $InstallDir from PATH."
+    }
+
+    # Remove entire .aca directory (binary + config)
+    if (Test-Path $AcaHome) {
+        Remove-Item -Recurse -Force $AcaHome
+        Write-Host "Removed $AcaHome (binary and configuration)."
+    }
+
+    Write-Host "$BinaryName uninstalled successfully."
+}
+
+function Install-Aca {
+    $Platform = "win-x64"
+
+    if ($Version -eq "latest") {
+        # Fetch latest version from version file (no API, no rate limits)
+        $Version = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/$Repo/$Branch/docs/early/aca-cli/latest-version.txt" -UseBasicParsing).Content.Trim()
+        if (-not $Version) {
+            throw "Could not determine latest version. Specify manually: -Version aca-cli-v0.1.0-early-access"
+        }
+        Write-Host "Latest version: $Version"
+    }
+    $Url = "https://github.com/$Repo/releases/download/$Version/$Version-$Platform.zip"
+
+    Write-Host "Downloading $BinaryName from $Url..."
+
+    # Create install directory
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    $TmpFile = Join-Path $env:TEMP "$BinaryName-$Platform.zip"
+    $TmpDir = Join-Path $env:TEMP "$BinaryName-extract"
+
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $TmpFile -UseBasicParsing
+        
+        if (Test-Path $TmpDir) { Remove-Item -Recurse -Force $TmpDir }
+        Expand-Archive -Path $TmpFile -DestinationPath $TmpDir -Force
+
+        Copy-Item -Path (Join-Path $TmpDir "$BinaryName.exe") -Destination (Join-Path $InstallDir "$BinaryName.exe") -Force
+    } finally {
+        Remove-Item -Force $TmpFile -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+    }
+
+    # Add to PATH if not already there
+    $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    if ($UserPath -notlike "*$InstallDir*") {
+        [Environment]::SetEnvironmentVariable("PATH", "$UserPath;$InstallDir", "User")
+        $env:PATH = "$env:PATH;$InstallDir"
+        Write-Host "Added $InstallDir to PATH."
+    }
+
+    Write-Host ""
+    Write-Host "$BinaryName installed successfully to $InstallDir\$BinaryName.exe"
+    Write-Host ""
+    Write-Host "Prerequisites:"
+    Write-Host "  Azure CLI (az) must be installed and logged in."
+    Write-Host "  Run 'az login' if you haven't already."
+    Write-Host ""
+    Write-Host "Restart your terminal, then run '$BinaryName --help' to get started."
+}
+
+if ($Uninstall) {
+    Uninstall-Aca
+} else {
+    Install-Aca
+}

--- a/docs/early/aca-cli/install.sh
+++ b/docs/early/aca-cli/install.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-# TODO: Change to "main" once merged
 REPO="microsoft/azure-container-apps"
 BRANCH="main"
 BINARY_NAME="aca"
@@ -21,7 +20,11 @@ detect_platform() {
     esac
 
     case "$ARCH" in
-        x86_64|amd64)  ARCH_TAG="x64" ;;
+        x86_64|amd64)
+            if [ "$OS_TAG" = "osx" ]; then
+                echo "Error: macOS x64 (Intel) is not supported. Only macOS ARM64 (Apple Silicon) is available."; exit 1
+            fi
+            ARCH_TAG="x64" ;;
         aarch64|arm64) ARCH_TAG="arm64" ;;
         *)             echo "Error: Unsupported architecture: $ARCH"; exit 1 ;;
     esac

--- a/docs/early/aca-cli/install.sh
+++ b/docs/early/aca-cli/install.sh
@@ -1,0 +1,116 @@
+#!/bin/sh
+set -e
+
+# TODO: Change to "main" once merged
+REPO="microsoft/azure-container-apps"
+BRANCH="aca-cli-preview"
+BINARY_NAME="aca"
+INSTALL_DIR="/usr/local/bin"
+
+# Allow overriding version; default to latest
+VERSION="${ACA_VERSION:-latest}"
+
+detect_platform() {
+    OS="$(uname -s)"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        Linux)  OS_TAG="linux" ;;
+        Darwin) OS_TAG="osx" ;;
+        *)      echo "Error: Unsupported OS: $OS"; exit 1 ;;
+    esac
+
+    case "$ARCH" in
+        x86_64|amd64)  ARCH_TAG="x64" ;;
+        aarch64|arm64) ARCH_TAG="arm64" ;;
+        *)             echo "Error: Unsupported architecture: $ARCH"; exit 1 ;;
+    esac
+
+    PLATFORM="${OS_TAG}-${ARCH_TAG}"
+}
+
+get_download_url() {
+    if [ "$VERSION" = "latest" ]; then
+        # Fetch latest version from version file (no API, no rate limits)
+        VERSION="$(curl -fsSL "https://raw.githubusercontent.com/${REPO}/${BRANCH}/docs/early/aca-cli/latest-version.txt" | tr -d '[:space:]')"
+        if [ -z "$VERSION" ]; then
+            echo "Error: Could not determine latest version."
+            echo "Specify a version manually: ACA_VERSION=aca-cli-v0.1.0-early-access $0"
+            exit 1
+        fi
+        echo "Latest version: ${VERSION}"
+    fi
+    URL="https://github.com/${REPO}/releases/download/${VERSION}/${VERSION}-${PLATFORM}.tar.gz"
+}
+
+uninstall() {
+    TARGET="${INSTALL_DIR}/${BINARY_NAME}"
+    ACA_HOME="${HOME}/.aca"
+
+    if [ ! -f "$TARGET" ] && [ ! -d "$ACA_HOME" ]; then
+        echo "${BINARY_NAME} is not installed."
+        exit 0
+    fi
+
+    # Remove binary
+    if [ -f "$TARGET" ]; then
+        if [ -w "$INSTALL_DIR" ]; then
+            rm -f "$TARGET"
+        else
+            echo "Removing ${TARGET} (requires sudo)..."
+            sudo rm -f "$TARGET"
+        fi
+        echo "Removed ${TARGET}"
+    fi
+
+    # Remove config directory
+    if [ -d "$ACA_HOME" ]; then
+        rm -rf "$ACA_HOME"
+        echo "Removed ${ACA_HOME} (configuration)."
+    fi
+
+    echo "${BINARY_NAME} uninstalled successfully from ${TARGET}"
+}
+
+install() {
+    detect_platform
+    echo "Detected platform: ${PLATFORM}"
+
+    get_download_url
+    echo "Downloading ${BINARY_NAME} from ${URL}..."
+
+    TMP_DIR="$(mktemp -d)"
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
+    curl -fsSL "$URL" -o "${TMP_DIR}/${BINARY_NAME}.tar.gz"
+    tar -xzf "${TMP_DIR}/${BINARY_NAME}.tar.gz" -C "$TMP_DIR"
+
+    # Install to INSTALL_DIR (try sudo if needed)
+    if [ ! -d "$INSTALL_DIR" ]; then
+        echo "Creating ${INSTALL_DIR} (requires sudo)..."
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
+
+    if [ -w "$INSTALL_DIR" ]; then
+        cp "${TMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+        chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+        sudo cp "${TMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
+        sudo chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
+
+    echo ""
+    echo "${BINARY_NAME} installed successfully to ${INSTALL_DIR}/${BINARY_NAME}"
+    echo ""
+    echo "Prerequisites:"
+    echo "  Azure CLI (az) must be installed and logged in."
+    echo "  Run 'az login' if you haven't already."
+    echo ""
+    echo "Run '${BINARY_NAME} --help' to get started."
+}
+
+case "${1:-}" in
+    --uninstall) uninstall ;;
+    *)           install ;;
+esac

--- a/docs/early/aca-cli/install.sh
+++ b/docs/early/aca-cli/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # TODO: Change to "main" once merged
 REPO="microsoft/azure-container-apps"
-BRANCH="aca-cli-preview"
+BRANCH="main"
 BINARY_NAME="aca"
 INSTALL_DIR="/usr/local/bin"
 

--- a/docs/early/aca-cli/latest-version.txt
+++ b/docs/early/aca-cli/latest-version.txt
@@ -1,0 +1,1 @@
+aca-cli-v0.1.0-early-access


### PR DESCRIPTION
## Summary

Adds install scripts, version tracking, and documentation for the ACA CLI Early Access release under `docs/early/aca-cli/`.

## Changes

- **install.sh** — Linux/macOS installer (auto-detects platform, supports `--uninstall`)
- **install.ps1** — Windows PowerShell installer (supports `-Uninstall`)
- **latest-version.txt** — Points to `aca-cli-v0.1.0-early-access`
- **README.md** — Install/uninstall instructions, prerequisites, supported platforms

## Related

- GitHub Release: https://github.com/microsoft/azure-container-apps/releases/tag/aca-cli-v0.1.0-early-access