### PR TITLE
Add skills marketplace with sandboxes skill

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "Azure-Container-Apps",
+  "metadata": {
+    "description": "Azure Container Apps skills marketplace — self-contained skills for coding agents (Copilot CLI, Claude Code).",
+    "version": "0.1.0"
+  },
+  "owner": {
+    "name": "Microsoft",
+    "url": "https://github.com/microsoft/azure-container-apps"
+  },
+  "plugins": [
+    {
+      "name": "sandboxes",
+      "source": "./plugin",
+      "description": "Sandboxes — hardware-isolated microVMs with snapshot/resume, scale-to-zero. Driven by the `aca` CLI; Python SDK also available.",
+      "version": "0.0.1-beta",
+      "skills": [
+        "./plugin/skills/sandboxes"
+      ]
+    }
+  ]
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "Azure-Container-Apps",
+  "description": "Azure Container Apps skills marketplace — sandboxes (and more, coming soon).",
+  "version": "0.0.1-beta",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/azure-container-apps",
+  "repository": "https://github.com/microsoft/azure-container-apps",
+  "license": "MIT",
+  "keywords": [
+    "azure",
+    "container-apps",
+    "sandbox",
+    "microvm",
+    "ai-agents",
+    "aca"
+  ],
+  "skills": "./skills/"
+}

--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "Azure-Container-Apps",
+  "description": "Azure Container Apps skills marketplace — sandboxes (and more, coming soon).",
+  "version": "0.0.1-beta",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/azure-container-apps",
+  "repository": "https://github.com/microsoft/azure-container-apps",
+  "license": "MIT",
+  "keywords": [
+    "azure",
+    "container-apps",
+    "sandbox",
+    "microvm",
+    "ai-agents",
+    "aca"
+  ],
+  "skills": "./skills/"
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,22 @@
+# Azure Container Apps Plugins Marketplace
+
+Skills for Azure Container Apps — install once, drive `aca` from natural language
+in your coding agent.
+
+## Install
+
+### GitHub Copilot CLI
+
+```bash
+# Add as a plugin marketplace
+/plugin marketplace add microsoft/azure-container-apps
+
+# Install all skills
+/plugin install sandboxes@Azure-Container-Apps
+```
+
+### Claude Code
+
+```bash
+claude plugin add microsoft/azure-container-apps
+```

--- a/plugin/skills/sandboxes/SKILL.md
+++ b/plugin/skills/sandboxes/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: sandboxes
+description: |
+  Sandboxes — hardware-isolated microVMs on Azure Container Apps for
+  running AI-generated code, coding agents, MCP servers, web apps, and
+  ephemeral workloads. Snapshot/resume, scale-to-zero, sub-second
+  startup, deny-default egress. Driven by the `aca` CLI (auth delegates
+  to `az login`).
+
+  Use when the user wants to: create or manage sandbox groups and
+  sandboxes; exec commands or open an interactive shell; read/write
+  files; expose ports; snapshot, stop, resume, commit to a disk, or
+  mount volumes; tighten egress; manage secrets, managed identity,
+  labels; apply YAML specs; or run scenarios like web apps, coding
+  agents, code interpreter, swarms, sandbox inception, computer-use,
+  MCP hosting, data processing, or developer workflows.
+
+  Triggers: "create sandbox", "sandbox group", "aca cli", "aca
+  sandbox", "azure container apps sandbox", "ACA sandbox", "microVM",
+  "isolated VM", "run untrusted code", "exec in sandbox", "sandbox
+  shell", "copy files to sandbox", "sandbox port", "sandbox snapshot",
+  "commit sandbox to disk", "sandbox volume", "mount volume sandbox",
+  "suspend sandbox", "resume sandbox", "sandbox lifecycle",
+  "auto-suspend sandbox", "sandbox secret", "sandbox managed identity",
+  "sandbox labels", "sandbox apply yaml", "egress deny", "egress
+  allow-list", "code interpreter", "agent swarm", "sandbox inception",
+  "coding agent sandbox", "computer use sandbox", "host mcp".
+---
+
+# Sandboxes
+
+Hardware-isolated microVMs on Azure Container Apps. Snapshot/resume,
+scale-to-zero, sub-second startup, deny-default egress. This skill
+drives sandboxes through the **`aca` CLI** — one command surface, no
+ambiguity. Self-contained — everything is under `references/` in this
+folder.
+
+## What it is
+
+- **Resource type:** `Microsoft.App/SandboxGroups` (preview).
+- **Isolation:** each sandbox is its own microVM, safe for untrusted code.
+- **Startup:** sub-second from a prewarmed pool; suspend/resume preserves
+  full memory + disk.
+- **Scale:** zero to thousands; pay nothing when idle.
+- **Auth:** `aca` delegates to `az login` — same identity, same MFA.
+
+> ⚠️ **The `az` CLI has no sandbox commands.** Sandbox groups and
+> sandboxes are managed by `aca` — **not** by `az containerapp …`. The
+> `az containerapp` commands are for the older Apps / Jobs surface and
+> do not touch sandboxes. If you see `az containerapp sandbox …` in a
+> snippet, it's wrong.
+
+## Get started
+
+| | Where |
+|---|---|
+| **Install** | [references/install.md](references/install.md) |
+| **Prerequisites** | [references/prerequisites.md](references/prerequisites.md) |
+| **Quick start** | [references/quickstart.md](references/quickstart.md) |
+| **Full CLI reference** | [references/reference.md](references/reference.md) |
+| **Scenario recipes** | [references/scenarios.md](references/scenarios.md) |
+
+After install, always confirm setup with `aca doctor` — it resolves
+subscription / RG / group / region / role and tells you which check
+is red.
+
+## Capabilities
+
+Everything the platform exposes. Each row is the starting point — open
+[references/reference.md](references/reference.md) for full flags and
+options.
+
+> Command rows below show only the **shape**. In real invocations:
+> - every `aca sandbox <verb>` takes `--id <sandbox-id>`;
+> - every `aca sandboxgroup <noun> <verb>` mutation takes `--name <group>`
+>   (or relies on the default group set via `--set-config`);
+> - omit these from copies into the shell and you'll get a CLI parse error.
+
+| #  | Capability                | What it does                                                                 | `aca` CLI |
+|----|---------------------------|------------------------------------------------------------------------------|-----------|
+| 00 | **Sandbox groups**        | Provision, list/get, assign Data Owner role, tear down.                      | `aca sandboxgroup create / list / get / role create / delete` |
+| 01 | **Sandboxes**             | Create, list, get, delete; cpu/memory/labels/env; parallel.                  | `aca sandbox create / list / get / delete` (+ `--cpu --memory --labels --env`) |
+| 02 | **Snapshots**             | Freeze a running sandbox; boot new ones from that point.                     | `aca sandbox snapshot --id <id> --name X` · `aca sandbox create --snapshot X` |
+| 03 | **Disks**                 | Public disks, build from container image, commit a running sandbox.          | `aca sandboxgroup disk list-public / create --image` · `aca sandbox commit --id <id> --name X` · `aca sandbox create --disk <public-name>` (or `--disk-id <id>` for private/committed disks) |
+| 04 | **Volumes**               | `AzureBlob` (shared) or `DataDisk` (block); mount at create or post-create.  | `aca sandboxgroup volume create --type AzureBlob` · `aca sandbox mount --volume X --path /mnt/x` |
+| 05 | **Lifecycle**             | Stop/resume; auto-suspend after idle; auto-delete after TTL.                 | `aca sandbox stop / resume` · `aca sandbox lifecycle set --auto-suspend 60` |
+| 06 | **Ports**                 | Expose an HTTP port; anonymous or Entra-gated; revoke.                       | `aca sandbox port add --port 8080 [--anonymous]` · `port list / remove` |
+| 07 | **Files**                 | write / read / list / stat / mkdir / delete inside the sandbox.              | `aca sandbox fs write --file ./local` · `fs cat / ls` · `fs cp <src> <dst>` (positional, `sbx-id:/path` syntax) |
+| 08 | **Egress**                | Deny-default outbound + host allow-list; audit decisions; YAML transforms.   | `aca sandbox egress set --default Deny --host-allow "*.host.com"` · `egress show / decisions / apply` |
+| 09 | **Secrets**               | Group-scoped key/value, fetched at runtime from inside the sandbox.          | `aca sandboxgroup secret upsert --name X --values "K=V"` · `secret list / delete` |
+| 10 | **Managed identity**      | System- or User-assigned MI on the group; grant RBAC for cross-group orchestration. | `aca sandboxgroup identity assign --system-assigned` (or `--user-assigned <res-id>`) · `identity show / remove` |
+| 11 | **Labels & selectors**    | `--labels k=v` at create time; AND-filter on list. Fleet management pattern. | `aca sandbox create --labels role=worker,tenant=t42` · `aca sandbox list -l role=worker` |
+| 12 | **Interactive shell**     | Real PTY into a running sandbox.                                             | `aca sandbox shell --id <id>` |
+| 13 | **YAML spec / `apply`**   | Declarative infra-as-code: `init`, `validate`, `apply`, `schema`.            | `aca sandbox init > sandbox.yaml` · `validate` · `apply --file sandbox.yaml` |
+| 14 | **`aca doctor`**          | Diagnose subscription / RG / group / region / role.                          | `aca doctor` |
+
+## Scenarios
+
+Composed patterns that combine the capabilities above. Full sketches
+in [references/scenarios.md](references/scenarios.md).
+
+- **Web apps** — start a server, expose a port anonymously, hit the URL.
+- **Coding agents in a sandbox** — run Copilot CLI / Claude Code / Codex
+  with deny-default egress and (optionally) token-swap rules.
+- **Code interpreter** — LLM generates → exec → observe → iterate;
+  snapshot between turns for rewind.
+- **Swarms** — orchestrator fans work across N worker sandboxes by
+  label selector.
+- **Sandbox inception** — orchestrator runs *inside* a sandbox and uses
+  its managed identity to drive a separate worker group. No credentials
+  in agent code.
+- **Computer-use** — LLM drives a real browser; watch live via noVNC.
+- **MCP hosting** — host an MCP server in a sandbox; expose via port or
+  Dev Tunnel.
+- **Data processing** — producer/consumer pipelines on shared
+  `AzureBlob` volumes.
+- **Developer workflows** — PR builds, ephemeral CI, on-demand dev envs.
+
+## Python SDK (separate)
+
+An early-access Python SDK (`azure-containerapps-sandbox`) is also
+available if you'd rather drive sandboxes from service code instead of
+the CLI. It is **out of scope for this skill** — when the user asks for
+Python, point them at the upstream README and stop:
+
+> https://github.com/microsoft/azure-container-apps/blob/main/docs/early/python-sdk/README.md
+
+Mixing CLI and SDK in the same answer confuses things. Pick one.

--- a/plugin/skills/sandboxes/references/install.md
+++ b/plugin/skills/sandboxes/references/install.md
@@ -1,0 +1,63 @@
+# Install the `aca` CLI
+
+The `aca` CLI is the primary surface for sandboxes. It delegates
+authentication to the Azure CLI (`az login`).
+
+## Linux / macOS
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
+```
+
+Pin a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh \
+  | ACA_VERSION=aca-cli-v0.1.0-early-access sh
+```
+
+## Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1 | iex
+```
+
+Pin a specific version:
+
+```powershell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Version aca-cli-v0.1.0-early-access
+```
+
+## Verify
+
+```bash
+aca --version
+# aca 1.0.0-beta.1
+```
+
+Then log in and run the doctor:
+
+```bash
+az login
+aca doctor
+```
+
+## Uninstall
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh -s -- --uninstall
+```
+
+```powershell
+# Windows
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Uninstall
+```
+
+## Supported platforms
+
+| Platform | Architecture |
+|---|---|
+| Linux   | x64    |
+| macOS   | ARM64  |
+| Windows | x64    |

--- a/plugin/skills/sandboxes/references/prerequisites.md
+++ b/plugin/skills/sandboxes/references/prerequisites.md
@@ -1,0 +1,52 @@
+# CLI prerequisites
+
+## Accounts and access
+
+- **Azure subscription** — one you can create resource groups in.
+  [Create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account).
+- **Microsoft Entra ID account** — personal Microsoft accounts are **not** supported.
+- **Role** — to create sandboxes inside a group you need the
+  `Container Apps SandboxGroup Data Owner` role on the group. The
+  [quickstart](quickstart.md) shows how to grant it to yourself.
+
+## Tools
+
+- **[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)** installed and logged in (`az login`).
+  The `aca` CLI delegates auth to `az login` — same identity, same MFA,
+  same conditional-access policies.
+- **An Azure subscription with a resource group.**
+- **`aca` CLI** — installed in one line; see [install.md](install.md).
+- **A shell** — Bash on Linux/macOS; PowerShell or Bash (Git Bash / WSL) on Windows.
+
+## Supported platforms
+
+| Platform | Architecture |
+|---|---|
+| Linux   | x64    |
+| macOS   | ARM64  |
+| Windows | x64    |
+
+## Region
+
+Sandboxes are a preview resource type. Start with a well-supported
+region such as `eastus2` or `westus2`. If a region rejects the group
+create, try another — `aca` will tell you which region the API rejected.
+
+## Doctor checklist
+
+`aca doctor` runs all of the following — green across the board means
+you are ready to create sandboxes:
+
+1. Azure CLI found on `PATH`.
+2. Azure CLI is logged in (`az account show` succeeds).
+3. A default subscription is resolved (flag, env, or config).
+4. A default resource group is resolved.
+5. A default sandbox group is resolved.
+6. A default region is resolved.
+7. The sandbox group exists in Azure.
+8. The caller has the `Container Apps SandboxGroup Data Owner` role on the group.
+
+Each line in `aca doctor` output also tells you **where** the value came
+from — `(flag)`, `(env)`, `(config: sandbox)`, or `(config)` — which is
+invaluable when debugging precedence. See
+[reference.md](reference.md#config) for the precedence model.

--- a/plugin/skills/sandboxes/references/quickstart.md
+++ b/plugin/skills/sandboxes/references/quickstart.md
@@ -1,0 +1,77 @@
+# CLI quick start
+
+Goal: log in, create a sandbox group, grant yourself access, create a
+sandbox, run a command, and clean up — all via the `aca` CLI.
+
+> Assumes `aca` is installed (see [install.md](install.md)) and the
+> Azure CLI is on your `PATH`. Full prereqs: [prerequisites.md](prerequisites.md).
+
+```bash
+# 0. Log in to Azure
+az login
+
+# 1. Create a resource group (skip if you have one)
+az group create --name my-rg --location eastus2
+
+# 2. Create a sandbox group (saves config automatically with --set-config)
+aca sandboxgroup create --name my-sandbox-group --location eastus2 --set-config
+
+# 3. Grant yourself data-plane access
+aca sandboxgroup role create \
+  --role "Container Apps SandboxGroup Data Owner" \
+  --principal-id $(az ad signed-in-user show --query id -o tsv)
+
+# 4. Verify setup
+aca doctor
+
+# 5. Create a sandbox
+aca sandbox create --disk ubuntu
+# Created sandbox: a1b2c3d4-1234-5678-9abc-def012345678
+
+# 6. Run a command
+aca sandbox exec --id <sandbox-id> -c "echo hello world && uname -a"
+
+# 7. Clean up
+aca sandbox delete --id <sandbox-id> --yes
+```
+
+`aca doctor` should print eight green checks:
+
+```
+✓ Azure CLI found
+✓ Azure CLI logged in
+✓ Subscription: a59d7183-… (config)
+✓ Resource group: my-rg (config)
+✓ Sandbox group: my-sandbox-group (config: sandbox)
+✓ Region: eastus2 (config: sandbox)
+✓ Sandbox group 'my-sandbox-group' exists in Azure
+✓ Container Apps SandboxGroup Data Owner role assigned
+
+aca 1.0.0-beta.1 — all checks passed
+```
+
+Defaults applied when flags are omitted:
+
+| Flag | Default |
+|---|---|
+| `--cpu`    | `1000m` (1 vCPU) |
+| `--memory` | `2048Mi` (2 GiB) |
+| auto-suspend | 300s (5 min idle → suspend) |
+
+Label + selector shortcut (target sandboxes without remembering IDs):
+
+```bash
+aca sandbox create --disk ubuntu --label name=dev
+aca sandbox exec -l "name=dev" -c "echo hello"
+```
+
+Tear down the whole group later:
+
+```bash
+aca sandboxgroup delete --name my-sandbox-group --yes
+```
+
+## What next
+
+- [reference.md](reference.md) — full `aca` CLI reference (auth, config, YAML, selectors, output, verbose).
+- [scenarios.md](scenarios.md) — patterns: web apps, coding agents, swarms, MCP hosting.

--- a/plugin/skills/sandboxes/references/reference.md
+++ b/plugin/skills/sandboxes/references/reference.md
@@ -1,0 +1,496 @@
+# `aca` CLI reference
+
+Full reference for the `aca` CLI. Jump to whichever section you need.
+
+> Verified against `aca 1.0.0-beta.1`.
+
+## Contents
+
+- [Auth](#auth)
+- [Help commands](#help-commands)
+- [Global flags and short forms](#global-flags-and-short-forms)
+- [Environment variables](#environment-variables)
+- [Config](#config)
+- [`doctor`](#doctor)
+- [YAML spec workflow](#yaml-spec-workflow)
+- [Selectors](#selectors)
+- [Output formats](#output-formats)
+- [Verbose and debug](#verbose-and-debug)
+
+---
+
+## Auth
+
+`aca` does not maintain its own credential store. Auth is delegated to
+the Azure CLI — same identity, same MFA, same conditional-access policies.
+
+```bash
+aca auth login    # delegates to `az login`
+aca auth status   # shows current ARM + data-plane auth
+```
+
+`aca auth status` output:
+
+```
+✓ ARM authenticated via Azure CLI
+✓ Data plane authenticated (https://dynamicsessions.io/.default)
+```
+
+### Switching subscriptions
+
+`aca` reads the active Azure CLI account by default. Switch it with `az`:
+
+```bash
+az account set --subscription <SUB_ID>
+```
+
+Or override per-command:
+
+```bash
+aca sandbox list -s <SUB_ID>
+```
+
+Or set a default in CLI config:
+
+```bash
+aca config set -s <SUB_ID>
+```
+
+### Managed identity (Azure-hosted)
+
+When running inside Azure (App Service, Container Apps, VM, Functions),
+use a managed identity:
+
+```bash
+aca sandbox list --managed-identity system            # system-assigned
+aca sandbox list --managed-identity <CLIENT_ID_UUID>  # user-assigned
+```
+
+Available on every command. Also settable via
+`ACA_SANDBOX_MANAGED_IDENTITY` or
+`aca config sandbox set --managed-identity …`.
+
+---
+
+## Help commands
+
+Every command, group, and sub-group responds to `--help` (or `-h`). The
+help text is the source of truth — examples, flags, env-var names, and
+defaults are all there.
+
+```bash
+aca --help                          # top-level: commands + global flags + quick start + scenarios
+aca <group> --help                  # group: list of sub-commands
+aca <group> <command> --help        # command: arguments, env vars, defaults, examples
+aca <group> <command> -h            # short summary
+```
+
+Top-level commands:
+
+| Command | Purpose |
+|---|---|
+| `aca auth`         | Log in and check authentication status |
+| `aca config`       | Manage CLI configuration |
+| `aca sandboxgroup` | Manage sandbox groups, disks, volumes, secrets, roles, regions |
+| `aca sandbox`      | Create and manage sandboxes (exec, shell, files, ports, egress, snapshots) |
+| `aca version`      | Show CLI version |
+| `aca doctor`       | Check prerequisites, config, and RBAC (8 checks) |
+| `aca help`         | Print help for any sub-command |
+
+---
+
+## Global flags and short forms
+
+Every command accepts these flags. Short forms are listed where they exist.
+
+| Flag | Short | Env var | Description |
+|---|---|---|---|
+| `--subscription`      | `-s` | `ACA_SUBSCRIPTION`               | Azure subscription ID |
+| `--resource-group`    | `-g` | `ACA_RESOURCE_GROUP`             | Resource group |
+| `--sandbox-group`     |      | `ACA_SANDBOX_GROUP`              | Default sandbox group (top-level commands) |
+| `--group`             |      |                                  | Sandbox group (on `sandbox` / `sandboxgroup` sub-commands) |
+| `--region`            |      | `ACA_REGION`                     | Data plane region |
+| `--output`            | `-o` |                                  | Output format: `table` (default) or `json` |
+| `--managed-identity`  |      | `ACA_SANDBOX_MANAGED_IDENTITY`   | `system` or a client-id UUID |
+| `--verbose`           |      |                                  | HTTP traces and resolved config |
+| `--debug`             |      |                                  | Verbose + transport details (⚠ may log secrets) |
+| `--help`              | `-h` |                                  | Show help |
+| `--version`           | `-V` |                                  | Print version (top-level only) |
+
+Sandbox lookup flags (on commands that target a sandbox):
+
+| Flag | Short | Description |
+|---|---|---|
+| `--id`       |      | Target by UUID |
+| `--selector` | `-l` | Target by label selector `"k=v,k2=v2"` |
+
+Other command-specific short forms:
+
+| Flag | Short | Used by |
+|---|---|---|
+| `--command` | `-c` | `aca sandbox exec`, `aca sandbox shell` |
+
+---
+
+## Environment variables
+
+Every global flag has an env-var equivalent. Set them once in your shell
+and skip the flags.
+
+| Env var | Equivalent flag |
+|---|---|
+| `ACA_SUBSCRIPTION`              | `-s`, `--subscription` |
+| `ACA_RESOURCE_GROUP`            | `-g`, `--resource-group` |
+| `ACA_SANDBOX_GROUP`             | `--sandbox-group` |
+| `ACA_REGION`                    | `--region` |
+| `ACA_SANDBOX_MANAGED_IDENTITY`  | `--managed-identity` |
+
+Env wins over CLI config but loses to an explicit flag. See
+[Config → Precedence](#precedence) below.
+
+---
+
+## Config
+
+`aca` config lives at `~/.aca/config.json` and has two user-facing sections.
+
+Stop typing `-s … -g … --sandbox-group …` on every command. Set once,
+work for the rest of the session — with a precedence model that lets CI
+override anything via env vars without editing files.
+
+### Sections
+
+| Section | What goes there |
+|---|---|
+| **Shared Defaults** | Subscription, resource group, region — used by every command that doesn't override them. |
+| **Sandbox** | Sandbox-specific keys: sandbox group, auto-resume behavior, current sandbox, managed identity, audience, allowed regions, and per-section overrides for sub/RG/region. |
+
+### See your current config
+
+```bash
+aca config show
+```
+
+Sample output:
+
+```
+Configuration:
+  Shared Defaults:
+    subscription     a59d7183-…
+    resource_group   my-rg
+    region           westus2
+
+  Sandbox:
+    subscription     (inherited)
+    resource_group   (inherited)
+    region           westus2
+    group            my-sandbox-group
+    auto_resume      true
+    current_sandbox  (not set)
+    managed_identity (not set)
+    audience         (not set)
+
+Config file: ~/.aca/config.json
+```
+
+`(inherited)` means the Sandbox section inherits from Shared Defaults for that key.
+
+### Set Shared Defaults
+
+```bash
+aca config set \
+  -s <SUB_ID> \
+  -g <RG> \
+  --sandbox-group <GROUP> \
+  --region westus2
+```
+
+| Flag | Effect |
+|---|---|
+| `-s`, `--subscription` | Default subscription for all commands |
+| `-g`, `--resource-group` | Default resource group |
+| `--region` | Default data-plane region |
+| `--sandbox-group` | Default sandbox group name |
+
+### Set Sandbox-specific config
+
+```bash
+aca config sandbox set \
+  --group my-sandbox-group \
+  --auto-resume true \
+  --sandbox <UUID>
+```
+
+| Flag | Effect |
+|---|---|
+| `-s`, `--subscription` | Override Shared subscription for sandbox commands only |
+| `-g`, `--resource-group` | Override Shared resource group for sandbox commands only |
+| `--region` | Override Shared region for sandbox commands only |
+| `--group` | Default sandbox group name |
+| `--auto-resume true\|false` | Auto-resume a suspended sandbox before operations |
+| `--managed-identity system\|<CLIENT_ID>` | Use a managed identity for auth |
+| `--audience <URL>` | Override OAuth audience/scope |
+| `--sandbox <UUID>` | "Current" sandbox ID. Pass `""` to clear |
+| `--add-region <REGION>` / `--remove-region <REGION>` | Add/remove a region from the allowed list (repeatable) |
+
+When `auto_resume` is `true`, suspended sandboxes resume automatically
+when you `exec` into them.
+
+### Precedence
+
+For any setting, the CLI resolves in this order (highest wins):
+
+1. **Command-line flag** (e.g. `-s <X>`)
+2. **Environment variable** (e.g. `ACA_SUBSCRIPTION=<X>`)
+3. **Sandbox-specific config**
+4. **Shared Defaults config**
+
+---
+
+## `doctor`
+
+`aca doctor` runs 8 prerequisite/config/RBAC checks and tells you what's wrong.
+
+```bash
+aca doctor
+```
+
+Sample output (all green):
+
+```
+✓ Azure CLI found
+✓ Azure CLI logged in
+✓ Subscription: a59d7183-… (config)
+✓ Resource group: my-rg (config)
+✓ Sandbox group: my-sandbox-group (config: sandbox)
+✓ Region: westus2 (config: sandbox)
+✓ Sandbox group 'my-sandbox-group' exists in Azure
+✓ Container Apps SandboxGroup Data Owner role assigned
+
+aca 1.0.0-beta.1 — all checks passed
+```
+
+Each line shows **where the value came from** — `(config)`,
+`(config: sandbox)`, `(env)`, `(flag)` — gold when debugging precedence.
+
+### What each check verifies, and how to fix it
+
+| Check | Means | Fix |
+|---|---|---|
+| Azure CLI found        | `az` is on `PATH` | Install Azure CLI |
+| Azure CLI logged in    | `az account show` succeeds | `az login` |
+| Subscription           | Resolves a default subscription | `aca config set -s <ID>` or `az account set` |
+| Resource group         | Resolves a default RG | `aca config set -g <RG>` |
+| Sandbox group          | Resolves a default sandbox group | `aca config sandbox set --group <NAME>` |
+| Region                 | Resolves a default region | `aca config sandbox set --region <REGION>` |
+| Sandbox group exists   | The group resource is found in Azure | `aca sandboxgroup create --name <NAME> --location <REGION> --set-config` |
+| Data Owner role        | Caller has `Container Apps SandboxGroup Data Owner` on the group | `aca sandboxgroup role create --role "Container Apps SandboxGroup Data Owner" --principal-id $(az ad signed-in-user show --query id -o tsv)` |
+
+---
+
+## YAML spec workflow
+
+Define a sandbox in YAML, validate, then apply. This is the
+infra-as-code story for sandboxes: check specs into git, code-review
+them, validate in CI before apply, and get editor autocomplete from the
+published JSON Schema.
+
+### The four commands
+
+| Command | Does |
+|---|---|
+| `aca sandbox init` | Print a starter spec to stdout |
+| `aca sandbox schema` | Print the JSON Schema for sandbox specs (for editor integration) |
+| `aca sandbox validate --file <FILE>` | Validate a spec file without creating anything |
+| `aca sandbox apply --file <FILE> [--no-wait]` | Create the sandbox from the spec |
+
+### End-to-end
+
+```bash
+aca sandbox init > sandbox.yaml
+```
+
+Generates:
+
+```yaml
+# ACA Sandbox manifest
+# Apply with: aca sandbox apply --file sandbox.yaml
+
+disk: ubuntu
+resources:
+  cpu: 1000m
+  memory: 2048Mi
+lifecycle:
+  autoSuspendPolicy:
+    enabled: true
+    interval: 300
+    mode: Memory
+egressPolicy:
+  defaultAction: Deny
+```
+
+Edit it (set labels, change `cpu` / `memory`, tighten egress), then:
+
+```bash
+aca sandbox validate --file sandbox.yaml
+aca sandbox apply --file sandbox.yaml
+```
+
+Add `--no-wait` to return as soon as the create is accepted (don't wait
+for `Running`).
+
+### Editor integration via `schema`
+
+```bash
+aca sandbox schema > sandbox.schema.json
+```
+
+Point your editor at it (`yaml.schemas` in VS Code, `yaml-language-server`
+in Neovim) for autocomplete and inline validation.
+
+### Validate in CI
+
+```bash
+aca sandbox validate --file sandbox.yaml
+```
+
+Exit code is non-zero on failure — drop this into a pre-merge check to
+catch spec drift before it hits Azure.
+
+---
+
+## Selectors
+
+Every command that operates on a sandbox accepts either a UUID or a
+label selector. UUIDs are unmemorable and ephemeral. Selectors let you
+script against labels you control. `-l "env=ci,role=worker"` works the
+same in your dev shell, your cleanup cron, your dashboard, and your
+alerting.
+
+### The two forms
+
+```bash
+# By ID (UUID)
+aca sandbox exec --id 0d9b1c4e-… -c "echo hello"
+
+# By label selector
+aca sandbox exec -l "name=dev" -c "echo hello"
+```
+
+### Selector grammar
+
+- `key=value` — match exactly
+- `key1=v1,key2=v2` — AND (all pairs must match)
+- Spaces around `=` and `,` are **not** allowed
+- For `get` and `delete`, the CLI matches the **first** sandbox satisfying the selector
+
+### Set labels at create-time
+
+The flag is `--label key=value`, repeatable:
+
+```bash
+aca sandbox create --disk ubuntu \
+  --label env=ci \
+  --label role=worker \
+  --label owner=alice
+```
+
+Then operate on it without quoting the UUID:
+
+```bash
+aca sandbox exec   -l "env=ci,role=worker" -c "./run.sh"
+aca sandbox stop   -l "env=ci,role=worker"
+aca sandbox delete -l "env=ci,role=worker"
+```
+
+### When to pick which
+
+| Use | Form |
+|---|---|
+| Long-lived dev sandbox       | Selector — friendlier in shell history |
+| Output of a previous command | UUID — already in your shell variable |
+| Batch over many              | `list -o json` + `jq` + UUID loop |
+| Cleanup by ownership tag     | Selector — labels are your contract |
+
+---
+
+## Output formats
+
+Every command supports `-o table|json`. Default is `table`.
+
+| Format | Use |
+|---|---|
+| `table` | Humans, interactive shells |
+| `json`  | Scripts, CI, pipelines |
+
+### Pipe JSON to `jq`
+
+Pull just the IDs:
+
+```bash
+aca sandbox list -o json | jq -r '.[].id'
+```
+
+Find Running sandboxes labeled `env=ci`:
+
+```bash
+aca sandbox list -o json | jq -r '.[] | select(.state=="Running" and .labels.env=="ci") | .id'
+```
+
+Bulk delete by tag:
+
+```bash
+aca sandbox list -o json \
+  | jq -r '.[] | select(.labels.env=="ci") | .id' \
+  | xargs -I{} aca sandbox delete --id {} --yes
+```
+
+### Diffing snapshots of the same resource
+
+```bash
+ID=<sandbox-id>
+aca sandbox get --id $ID -o json | jq -S . > before.json
+# ... do something ...
+aca sandbox get --id $ID -o json | jq -S . > after.json
+diff before.json after.json
+```
+
+---
+
+## Verbose and debug
+
+When a command does the wrong thing, `--verbose` shows exactly what.
+
+### `--verbose`
+
+```bash
+aca sandbox list --verbose
+```
+
+Outputs:
+
+- The **resolved config** dump (where each value came from: flag, env, sandbox-config, shared-config)
+- HTTP **request line**, headers, and status for each call
+- Response headers (bodies elided)
+
+### `--debug`
+
+```bash
+aca sandbox list --debug
+```
+
+Includes everything `--verbose` does **plus** transport-level details
+(TLS, retries, raw response bodies).
+
+> ⚠ `--debug` may log sensitive data (secret values, tokens in error
+> bodies). Don't share the output of a `--debug` run without reviewing
+> it first.
+
+### Capture to a file
+
+```bash
+aca sandbox apply --file sandbox.yaml --verbose 2> aca.log
+```
+
+Stdout stays clean for piping; verbose / debug traces go to stderr so
+you can capture them separately.

--- a/plugin/skills/sandboxes/references/scenarios.md
+++ b/plugin/skills/sandboxes/references/scenarios.md
@@ -1,0 +1,219 @@
+# Scenarios — when sandboxes shine
+
+Composed patterns that combine multiple sandbox capabilities. Each
+entry has a "when to use" and a minimal command sketch.
+
+---
+
+## 1. Web apps
+
+**When:** you have a web server and want a public URL in under a minute
+without provisioning ingress, certs, or a load balancer.
+
+**Sketch:**
+
+```bash
+SBX=$(aca sandbox create --disk ubuntu -o json | jq -r .id)
+
+# Upload + start
+aca sandbox fs write --id $SBX --path /app/server.py --file ./server.py
+aca sandbox exec --id $SBX -c "nohup python3 /app/server.py > /tmp/srv.log 2>&1 &"
+
+# Expose
+URL=$(aca sandbox port add --id $SBX --port 8080 --anonymous -o json | jq -r .url)
+echo "$URL"
+```
+
+Variants:
+
+- **simple-anonymous** — open to the internet (above).
+- **authenticated** — Entra-gated port (omit `--anonymous`).
+
+---
+
+## 2. Coding agents in a sandbox
+
+**When:** you want to run Copilot CLI, Claude Code, Codex, or any other
+coding agent in an isolated VM with deny-default egress, so the agent
+can only reach the endpoints you allow.
+
+**Sketch:**
+
+```bash
+# Per-task sandbox with deny-default egress + allow-list
+SBX=$(aca sandbox create --disk ubuntu --label task=copilot-run -o json | jq -r .id)
+aca sandbox egress set --id $SBX \
+  --default Deny \
+  --host-allow "api.githubcopilot.com" \
+  --host-allow "*.githubusercontent.com"
+
+aca sandbox exec --id $SBX -c "curl -fsSL https://github.com/cli/cli/releases/.../gh.tar.gz | tar -xz && ./gh ..."
+```
+
+Token-swap (inject the agent's auth header on egress, so the token
+never lands in the sandbox filesystem) — via the YAML policy:
+
+```bash
+aca sandbox egress init > egress-policy.yaml
+# edit egress-policy.yaml: add a rule with host: api.githubcopilot.com
+# and a header transform Authorization=Bearer <TOKEN>
+aca sandbox egress apply --id $SBX --file egress-policy.yaml
+```
+
+---
+
+## 3. Code interpreter
+
+**When:** an LLM generates code in a loop — generate, run, observe,
+iterate — and you need a fresh isolated environment per session.
+
+**Sketch:**
+
+```bash
+SBX=$(aca sandbox create --disk ubuntu --label kind=interpreter -o json | jq -r .id)
+
+# Loop:
+#   1. LLM emits code
+#   2. write -> exec -> capture stdout/stderr
+#   3. feed back into prompt
+aca sandbox fs write --id $SBX --path /tmp/step.py --file ./step.py
+aca sandbox exec --id $SBX -c "python3 /tmp/step.py" -o json
+```
+
+Snapshot between turns so you can rewind:
+
+```bash
+aca sandbox snapshot --id $SBX --name turn-3
+```
+
+---
+
+## 4. Swarms
+
+**When:** one orchestrator wants to fan work out across N worker
+sandboxes (rendering, scraping, eval, batch inference).
+
+**Sketch:**
+
+```bash
+# Orchestrator sandbox spawns workers in the same group via the
+# group's managed identity (no secrets needed inside the sandbox).
+BATCH_ID="batch-$(date +%s)"
+for i in $(seq 1 10); do
+  aca sandbox create --disk ubuntu \
+    --label role=worker --label batch=$BATCH_ID \
+    --no-wait
+done
+
+# Fan-out work by selector
+aca sandbox list -l "role=worker,batch=$BATCH_ID" -o json \
+  | jq -r '.[].id' \
+  | xargs -I{} -P 10 aca sandbox exec --id {} -c "./run-shard.sh"
+
+# Clean up — selector delete only matches one sandbox; iterate.
+aca sandbox list -l "role=worker,batch=$BATCH_ID" -o json \
+  | jq -r '.[].id' \
+  | xargs -I{} aca sandbox delete --id {} --yes
+```
+
+Add a shared AzureBlob volume to the group for durable scratch space
+across workers (`aca sandboxgroup volume …`).
+
+---
+
+## 5. Computer-use
+
+**When:** an LLM with computer-use capability drives a real browser
+inside a sandbox (form filling, web research, end-to-end tests). Watch
+live via noVNC.
+
+**Sketch:**
+
+```bash
+SBX=$(aca sandbox create --disk ubuntu --cpu 2000m --memory 4096Mi -o json | jq -r .id)
+aca sandbox exec --id $SBX -c "apt-get install -y chromium x11vnc novnc && start-desktop.sh"
+
+# Expose noVNC for the human to watch
+aca sandbox port add --id $SBX --port 6080 --anonymous
+```
+
+The LLM (Azure OpenAI `computer-use-preview` or similar) drives the
+browser via screenshot + click/keys actions sent through `sandbox exec`.
+
+---
+
+## 6. MCP hosting
+
+**When:** you want to host a Model Context Protocol (MCP) server in a
+sandbox for AI clients to connect to over HTTPS.
+
+**Sketch (public via `port add`):**
+
+```bash
+SBX=$(aca sandbox create --disk ubuntu -o json | jq -r .id)
+aca sandbox exec --id $SBX -c "npx -y @excalidraw/mcp-server &"
+aca sandbox port add --id $SBX --port 3000 --anonymous
+```
+
+**Sketch (no inbound port — Dev Tunnels from inside the sandbox):**
+
+```bash
+SBX=$(aca sandbox create --disk ubuntu -o json | jq -r .id)
+aca sandbox exec --id $SBX -c "npx -y @excalidraw/mcp-server &"
+aca sandbox exec --id $SBX -c "devtunnel host -p 3000 --allow-anonymous"
+# Tunnel URL is printed by devtunnel; share it with the MCP client.
+```
+
+---
+
+## 7. Data processing
+
+**When:** producer/consumer pipelines that need shared scratch space
+across short-lived sandboxes.
+
+**Sketch:**
+
+```bash
+# Create a group-level shared volume (default type: AzureBlob)
+aca sandboxgroup volume create --name shared --type AzureBlob
+
+# Create the sandboxes, then mount the volume into each
+SBX_P=$(aca sandbox create --disk ubuntu --label role=producer -o json | jq -r .id)
+aca sandbox mount --id $SBX_P --volume shared --path /data
+
+SBX_C=$(aca sandbox create --disk ubuntu --label role=consumer -o json | jq -r .id)
+aca sandbox mount --id $SBX_C --volume shared --path /data
+```
+
+Producers write to `/data/inbox/`, consumers drain it. Sandboxes
+suspend when idle and pay nothing.
+
+---
+
+## 8. Developer workflows
+
+**When:** PR builds, ephemeral CI, on-demand dev environments. A fresh
+sandbox per PR or per developer, deleted on close.
+
+**Sketch:**
+
+```bash
+SBX=$(aca sandbox create --disk ubuntu \
+  --label pr=$PR_NUMBER --label kind=ci -o json | jq -r .id)
+aca sandbox fs write --id $SBX --path /repo.tar.gz --file ./repo.tar.gz
+aca sandbox exec --id $SBX -c "cd /tmp && tar xzf /repo.tar.gz && make test"
+aca sandbox delete --id $SBX --yes
+```
+
+---
+
+## 9. Sandbox-backed agent frameworks
+
+**When:** you're using an agent framework (OpenAI Agents SDK, Claude
+Managed Agents, LangChain) and want sandboxes to be the tool-execution
+backend instead of the local machine.
+
+**Sketch:** the framework's "tool" implementation calls
+`aca sandbox exec --id $SBX -c "<tool-cmd>"` (or the equivalent API)
+and returns the stdout/stderr to the agent. Each conversation gets its
+own sandbox, snapshotted between turns for rewind.

--- a/plugin/skills/sandboxes/version.json
+++ b/plugin/skills/sandboxes/version.json
@@ -1,0 +1,4 @@
+{
+  "name": "sandboxes",
+  "version": "0.0.1-beta"
+}


### PR DESCRIPTION
## What

Introduces a **skills marketplace** at the root of the repo, starting
with a single self-contained `sandboxes` skill that teaches an AI
coding agent (Copilot CLI, Claude Code, etc.) how to drive the Azure
Container Apps **Sandboxes** preview through the `aca` CLI.

Install command for end users:

```
/plugin install sandboxes@Azure-Container-Apps
```

## Layout

```
marketplace.json                  # marketplace metadata (one entry: sandboxes)
plugin/
  README.md                       # one-paragraph install snippet
  .plugin/plugin.json             # Copilot CLI manifest
  .claude-plugin/plugin.json      # Claude Code manifest
  skills/
    sandboxes/
      SKILL.md                    # always-loaded — capabilities + decision rules
      version.json
      references/                 # progressively-disclosed, CLI-only
        install.md                # install / pin / uninstall
        prerequisites.md          # accounts, tools, supported platforms
        quickstart.md             # first sandbox end-to-end
        reference.md              # full aca CLI reference (auth, config, YAML, selectors, output, verbose)
        scenarios.md              # 9 composed patterns (web apps, coding agents, swarms, MCP, computer-use, ...)
```

## What the skill covers

15 platform capabilities — sandbox groups, sandboxes, snapshots,
disks, volumes, lifecycle, ports, files, egress, secrets, managed
identity, labels & selectors, interactive shell, YAML spec/`apply`,
`aca doctor` — each row in the SKILL.md table points at a real `aca`
command verified against `docs/early/aca-cli/README.md` and the
`samples/sandboxes/guides/` walkthroughs.

The Python SDK is intentionally **out of scope** for this skill (a
short note at the end of SKILL.md points users at
`docs/early/python-sdk/README.md`). Two surfaces in one skill
confused agents and produced mixed CLI+SDK answers.

## Self-contained

No cross-repo or cross-folder references — everything the agent needs
loads from `plugin/skills/sandboxes/`. The only external URLs are the
canonical `install.sh` / `install.ps1` endpoints and the single SDK
README pointer.

## Validation

- All 4 JSON manifests parse.
- All in-skill markdown links resolve.
- Rubber-duck deep pass against `docs/early/aca-cli/README.md` +
  guides 00-12: every `aca` command shape, flag, role string, default
  value, and example flow corrected. Notable fixes: `--disk` vs
  `--disk-id` for committed disks, `fs cp` is positional not `--file`,
  selector-delete only matches the first sandbox, default volume
  type is `AzureBlob` not `AzureFiles`.

## Out of scope

- The early-access `aca` CLI itself (this PR consumes it, doesn't
  ship it).
- The Python SDK (linked, not redocumented).
- Root `README.md` (untouched by request).
