### PR TITLE
Fix sandboxes skill description exceeding 1024-char limit

### DIFF
--- a/plugin/skills/sandboxes/SKILL.md
+++ b/plugin/skills/sandboxes/SKILL.md
@@ -2,29 +2,24 @@
 name: sandboxes
 description: |
   Sandboxes — hardware-isolated microVMs on Azure Container Apps for
-  running AI-generated code, coding agents, MCP servers, web apps, and
+  AI-generated code, coding agents, MCP servers, web apps, and
   ephemeral workloads. Snapshot/resume, scale-to-zero, sub-second
-  startup, deny-default egress. Driven by the `aca` CLI (auth delegates
-  to `az login`).
+  startup, deny-default egress. Driven by the `aca` CLI (auth via
+  `az login`).
 
-  Use when the user wants to: create or manage sandbox groups and
-  sandboxes; exec commands or open an interactive shell; read/write
-  files; expose ports; snapshot, stop, resume, commit to a disk, or
-  mount volumes; tighten egress; manage secrets, managed identity,
-  labels; apply YAML specs; or run scenarios like web apps, coding
-  agents, code interpreter, swarms, sandbox inception, computer-use,
-  MCP hosting, data processing, or developer workflows.
+  Use when the user wants to: create/manage sandbox groups and
+  sandboxes; exec or open a shell; read/write files; expose ports;
+  snapshot, stop, resume, commit to disk; mount volumes; tighten
+  egress; manage secrets, identity, labels; apply YAML; or run
+  scenarios like web apps, coding agents, code interpreter, swarms,
+  computer-use, or MCP hosting.
 
   Triggers: "create sandbox", "sandbox group", "aca cli", "aca
-  sandbox", "azure container apps sandbox", "ACA sandbox", "microVM",
-  "isolated VM", "run untrusted code", "exec in sandbox", "sandbox
-  shell", "copy files to sandbox", "sandbox port", "sandbox snapshot",
-  "commit sandbox to disk", "sandbox volume", "mount volume sandbox",
-  "suspend sandbox", "resume sandbox", "sandbox lifecycle",
-  "auto-suspend sandbox", "sandbox secret", "sandbox managed identity",
-  "sandbox labels", "sandbox apply yaml", "egress deny", "egress
-  allow-list", "code interpreter", "agent swarm", "sandbox inception",
-  "coding agent sandbox", "computer use sandbox", "host mcp".
+  sandbox", "microVM", "run untrusted code", "exec in sandbox",
+  "sandbox shell", "sandbox port", "sandbox snapshot", "commit sandbox
+  to disk", "mount volume sandbox", "suspend/resume sandbox", "sandbox
+  secret", "sandbox managed identity", "egress allow-list", "code
+  interpreter", "agent swarm", "coding agent sandbox", "host mcp".
 ---
 
 # Sandboxes

--- a/plugin/skills/sandboxes/version.json
+++ b/plugin/skills/sandboxes/version.json
@@ -1,4 +1,4 @@
 {
   "name": "sandboxes",
-  "version": "0.0.1-beta"
+  "version": "0.0.2-beta"
 }


### PR DESCRIPTION
Fixes #1726.

## Problem

The `sandboxes` skill at `plugin/skills/sandboxes/SKILL.md` has a frontmatter `description` of **1386 chars**, which exceeds the **1024-char** limit enforced by Copilot CLI. When installed via `sandboxes@Azure-Container-Apps`, the skill is silently rejected at load time:

```
skill_errors: ["…/Azure-Container-Apps/sandboxes/skills/sandboxes/SKILL.md: Skill description must be at most 1024 characters"]
```

(Found in `~/.copilot/logs/process-*.log`.)

The skill is present on disk but never registered with the agent, so users can never trigger it.

## Fix

- **`plugin/skills/sandboxes/SKILL.md`** — trimmed the `description` block from 1386 → **1007 chars**, preserving the `what / when / triggers` three-stanza structure and all primary trigger phrases. Dropped phrases that overlap semantically with kept ones:
  - `"azure container apps sandbox"`, `"ACA sandbox"` (covered by `"aca sandbox"` + `"aca cli"`)
  - `"isolated VM"` (covered by `"microVM"`)
  - `"sandbox lifecycle"`, `"auto-suspend sandbox"`, `"suspend sandbox"`, `"resume sandbox"` (collapsed into `"suspend/resume sandbox"`)
  - `"copy files to sandbox"` (covered by `"exec in sandbox"` + the body)
  - `"sandbox volume"` (covered by `"mount volume sandbox"`)
  - `"sandbox labels"`, `"sandbox apply yaml"` (rare-phrasing tail; covered by the body)
  - `"egress deny"` (covered by `"egress allow-list"` + body)
  - `"sandbox inception"`, `"computer use sandbox"` (rare-phrasing tails)

- **`plugin/skills/sandboxes/version.json`** — bumped `0.0.1-beta` → `0.0.2-beta` so already-installed clients pick up the fix on next `update`.

## Verification

```
$ python3 -c "
import yaml
with open('plugin/skills/sandboxes/SKILL.md') as f:
    fm = f.read().split('---')[1]
print(len(yaml.safe_load(fm)['description']))
"
1007
```

Locally applied the same edit under `~/.copilot/installed-plugins/.../SKILL.md` and the skill loads successfully after a CLI restart.

## Follow-up suggestions (not in this PR)

- Add a publish-time lint that fails if any `SKILL.md` `description` exceeds 1024 chars, so this can't regress.
- Consider documenting the limit alongside the skill authoring guidance.
