### PR TITLE
Improve sandboxes skill frontmatter for install discoverability

### DIFF
--- a/plugin/skills/sandboxes/SKILL.md
+++ b/plugin/skills/sandboxes/SKILL.md
@@ -1,25 +1,24 @@
 ---
 name: sandboxes
 description: |
-  Sandboxes — hardware-isolated microVMs on Azure Container Apps for
-  AI-generated code, coding agents, MCP servers, web apps, and
-  ephemeral workloads. Snapshot/resume, scale-to-zero, sub-second
-  startup, deny-default egress. Driven by the `aca` CLI (auth via
-  `az login`).
+  Hardware-isolated microVMs on Azure Container Apps for AI-generated
+  code, coding agents, MCP servers, web apps, ephemeral workloads.
+  Snapshot/resume, scale-to-zero, sub-second startup, deny-default
+  egress. Driven by the `aca` CLI (auth via `az login`).
 
-  Use when the user wants to: create/manage sandbox groups and
-  sandboxes; exec or open a shell; read/write files; expose ports;
-  snapshot, stop, resume, commit to disk; mount volumes; tighten
-  egress; manage secrets, identity, labels; apply YAML; or run
-  scenarios like web apps, coding agents, code interpreter, swarms,
-  computer-use, or MCP hosting.
+  If `aca` is missing or the user asks to install it, read
+  `references/install.md` first. The `aca` CLI is ONLY distributed
+  via GitHub Releases (microsoft/azure-container-apps) — NOT on npm,
+  pip, winget, brew, or any package manager. Don't guess.
 
-  Triggers: "create sandbox", "sandbox group", "aca cli", "aca
-  sandbox", "microVM", "run untrusted code", "exec in sandbox",
-  "sandbox shell", "sandbox port", "sandbox snapshot", "commit sandbox
-  to disk", "mount volume sandbox", "suspend/resume sandbox", "sandbox
-  secret", "sandbox managed identity", "egress allow-list", "code
-  interpreter", "agent swarm", "coding agent sandbox", "host mcp".
+  Triggers: "install aca", "install aca cli", "setup aca", "aca
+  doctor", "aca login", "command not found: aca", "create sandbox",
+  "sandbox group", "aca cli", "aca sandbox", "microVM", "run untrusted
+  code", "exec in sandbox", "sandbox shell", "sandbox port", "sandbox
+  snapshot", "commit sandbox to disk", "sandbox volume", "sandbox
+  secret", "sandbox identity", "egress allow-list", "apply sandbox
+  yaml", "code interpreter", "agent swarm", "coding agent sandbox",
+  "host mcp".
 ---
 
 # Sandboxes

--- a/plugin/skills/sandboxes/SKILL.md
+++ b/plugin/skills/sandboxes/SKILL.md
@@ -4,21 +4,22 @@ description: |
   Hardware-isolated microVMs on Azure Container Apps for AI-generated
   code, coding agents, MCP servers, web apps, ephemeral workloads.
   Snapshot/resume, scale-to-zero, sub-second startup, deny-default
-  egress. Driven by the `aca` CLI (auth via `az login`).
+  egress. Driven by `aca` CLI (auth via `az login`).
 
-  If `aca` is missing or the user asks to install it, read
-  `references/install.md` first. The `aca` CLI is ONLY distributed
-  via GitHub Releases (microsoft/azure-container-apps) — NOT on npm,
-  pip, winget, brew, or any package manager. Don't guess.
+  Use when the user wants to: create/manage sandbox groups and
+  sandboxes; exec or open a shell; read/write files; expose ports;
+  snapshot, stop, resume, commit to disk; mount volumes; tighten
+  egress; manage secrets, identity, labels; apply YAML; or run
+  scenarios like web apps, coding agents, code interpreter, swarms,
+  computer-use, or MCP hosting.
 
-  Triggers: "install aca", "install aca cli", "setup aca", "aca
-  doctor", "aca login", "command not found: aca", "create sandbox",
-  "sandbox group", "aca cli", "aca sandbox", "microVM", "run untrusted
-  code", "exec in sandbox", "sandbox shell", "sandbox port", "sandbox
-  snapshot", "commit sandbox to disk", "sandbox volume", "sandbox
-  secret", "sandbox identity", "egress allow-list", "apply sandbox
-  yaml", "code interpreter", "agent swarm", "coding agent sandbox",
-  "host mcp".
+  If `aca` is missing, read `references/install.md` first. `aca`
+  ships ONLY via GitHub Releases (microsoft/azure-container-apps);
+  not npm/pip/winget/brew. Don't guess.
+
+  Triggers: install aca, install aca cli, setup aca, aca doctor, aca
+  login, command not found: aca, create sandbox, sandbox group, aca
+  cli, aca sandbox, microVM, code interpreter, agent swarm, host mcp.
 ---
 
 # Sandboxes

--- a/plugin/skills/sandboxes/SKILL.md
+++ b/plugin/skills/sandboxes/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: sandboxes
 description: |
-  Hardware-isolated microVMs on Azure Container Apps for AI-generated
-  code, coding agents, MCP servers, web apps, ephemeral workloads.
-  Snapshot/resume, scale-to-zero, sub-second startup, deny-default
-  egress. Driven by `aca` CLI (auth via `az login`).
+  Azure Container Apps sandboxes let you run untrusted code, agents,
+  MCP servers, and web apps in hardware-isolated microVMs.
+  Supports snapshot/resume, scale-to-zero, deny-default egress, and is
+  managed with `aca` CLI using `az login`.
 
   Use when the user wants to: create/manage sandbox groups and
   sandboxes; exec or open a shell; read/write files; expose ports;
@@ -19,7 +19,8 @@ description: |
 
   Triggers: install aca, install aca cli, setup aca, aca doctor, aca
   login, command not found: aca, create sandbox, sandbox group, aca
-  cli, aca sandbox, microVM, code interpreter, agent swarm, host mcp.
+  cli, aca sandbox, exec in sandbox, microVM, code interpreter, agent
+  swarm, host mcp.
 ---
 
 # Sandboxes


### PR DESCRIPTION
Improves the `sandboxes` skill frontmatter so requests like *"install aca cli"* activate the skill, and prevents agents from guessing third-party package names for `aca`.

- Add install triggers: `install aca`, `install aca cli`, `setup aca`, `aca doctor`, `aca login`, `command not found: aca`.
- Add explicit note that `aca` is **only** distributed via GitHub Releases (not npm/pip/winget/brew) and to read `references/install.md` first.
- Replace prose `Covers` section with sandbox-qualified compound triggers (`sandbox volume/secret/identity/port/shell/snapshot`, etc.) to avoid false-positive matches on bare nouns.

Frontmatter description: 1020 / 1024 chars.