### PR TITLE
fix(skill/sandboxes): use canonical aka.ms install URLs and aca auth login

### DIFF
--- a/plugin/skills/sandboxes/references/install.md
+++ b/plugin/skills/sandboxes/references/install.md
@@ -1,31 +1,31 @@
 # Install the `aca` CLI
 
-The `aca` CLI is the primary surface for sandboxes. It delegates
-authentication to the Azure CLI (`az login`).
+The `aca` CLI is the primary surface for sandboxes. It owns the auth verb
+(`aca auth login`), which delegates to Azure CLI (`az login`) under the hood.
 
 ## Linux / macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
+curl -fsSL https://aka.ms/aca-cli-install | sh
 ```
 
 Pin a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh \
+curl -fsSL https://aka.ms/aca-cli-install \
   | ACA_VERSION=aca-cli-v0.1.0-early-access sh
 ```
 
 ## Windows (PowerShell)
 
 ```powershell
-irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1 | iex
+irm https://aka.ms/aca-cli-install-ps | iex
 ```
 
 Pin a specific version:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Version aca-cli-v0.1.0-early-access
+& ([scriptblock]::Create((irm https://aka.ms/aca-cli-install-ps))) -Version aca-cli-v0.1.0-early-access
 ```
 
 ## Verify
@@ -38,20 +38,24 @@ aca --version
 Then log in and run the doctor:
 
 ```bash
-az login
+aca auth login
 aca doctor
 ```
+
+> `aca auth login` is the canonical CLI entry point. It delegates to
+> `az login` under the hood, so if `az` is already authenticated you can
+> skip the login step. Use `aca auth status` to check.
 
 ## Uninstall
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh -s -- --uninstall
+curl -fsSL https://aka.ms/aca-cli-install | sh -s -- --uninstall
 ```
 
 ```powershell
 # Windows
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Uninstall
+& ([scriptblock]::Create((irm https://aka.ms/aca-cli-install-ps))) -Uninstall
 ```
 
 ## Supported platforms


### PR DESCRIPTION
Switches `plugin/skills/sandboxes/references/install.md` to the canonical install surface documented in the ACA Sandboxes ground-truth docs.

## Changes

| Before | After |
|---|---|
| `curl ... raw.githubusercontent.com/.../install.sh \| sh` | `curl -fsSL https://aka.ms/aca-cli-install \| sh` |
| `irm raw.githubusercontent.com/.../install.ps1 \| iex` | `irm https://aka.ms/aca-cli-install-ps \| iex` |
| `az login` | `aca auth login` (delegates to `az login` under the hood) |

Both aka.ms shortcuts already redirect to the same install scripts (verified `301 \u2192 raw.githubusercontent.com/.../install.{sh,ps1}`), so behavior is identical \u2014 only the user-facing URL changes. `aca auth login` is a real subcommand on `aca 1.0.0-beta.1` (`Commands: login | status | help`, *Log in to Azure (delegates to az login)*).

## Why

Surfaced by the ACA Sandboxes Vally eval suite (Run 3): `pos-install-aca-linux`, `pos-install-aca-macos`, `pos-install-aca-windows` all failed `output-contains` graders looking for `https://aka.ms/aca-cli-install` and `aca auth login` against the docs ground truth. Eval suite \u2192 `coreai-microsoft/adc-devx#214` (EMU).

## Risk

Zero. Behavior identical; only the URL surface and auth verb change. `az login` still works for users who use it directly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>