### PR TITLE
docs(python-sdk): switch install instructions to PyPI

### DIFF
--- a/docs/early/python-sdk/README.md
+++ b/docs/early/python-sdk/README.md
@@ -14,7 +14,7 @@ Python SDK for Azure Container Apps sandboxes. Create sandbox groups, sandboxes,
 ## Install
 
 ```bash
-pip install https://github.com/microsoft/azure-container-apps/releases/download/python-sdk-v0.1.0b1-early-access/azure_containerapps_sandbox-0.1.0b1-py3-none-any.whl
+pip install azure-containerapps-sandbox
 ```
 
 For management setup (resource group and role assignment):
@@ -486,7 +486,7 @@ orchestrator = client.begin_create_sandbox(
 
 ```python
 # Install SDK inside the sandbox
-orchestrator.exec("pip install <sdk-wheel-url> azure-identity --quiet")
+orchestrator.exec("pip install azure-containerapps-sandbox azure-identity --quiet")
 
 # Write a script that creates child sandboxes using managed identity
 orchestrator.write_file("/tmp/spawn.py", """

--- a/docs/early/python-sdk/complete-reference.md
+++ b/docs/early/python-sdk/complete-reference.md
@@ -32,10 +32,10 @@ Reference documentation for the `azure-containerapps-sandbox` Python SDK. Covers
 
 ## Installation
 
-Install the SDK wheel from the early-access GitHub release:
+Install the SDK from PyPI:
 
 ```bash
-pip install https://github.com/microsoft/azure-container-apps/releases/download/python-sdk-v0.1.0b1-early-access/azure_containerapps_sandbox-0.1.0b1-py3-none-any.whl
+pip install azure-containerapps-sandbox
 ```
 
 For one-time setup that creates a resource group and assigns RBAC, also install the Azure management libraries:


### PR DESCRIPTION
The `azure-containerapps-sandbox` package is now published on PyPI (https://pypi.org/project/azure-containerapps-sandbox/), so docs now point users to `pip install azure-containerapps-sandbox` instead of the GitHub release wheel URL.

The corresponding GitHub release (`python-sdk-v0.1.0b1-early-access`) and tag have been deleted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>