### PR TITLE
Pin SHA-256 hashes in aca-cli/preview/latest-version.txt and verify in installers

### DIFF
--- a/aca-cli/preview/README.md
+++ b/aca-cli/preview/README.md
@@ -59,6 +59,40 @@ curl -fsSL https://aka.ms/aca-cli-install | sh -s -- --uninstall
 
 The installers default to the tag pinned in [`latest-version.txt`](./latest-version.txt) — currently **`aca-cli-v0.1.0-preview`**. See the [release page](https://github.com/microsoft/azure-container-apps/releases/tag/aca-cli-v0.1.0-preview) for archive downloads and release notes.
 
+## Integrity verification
+
+The installers verify the downloaded archive against a SHA-256 hash pinned in [`latest-version.txt`](./latest-version.txt) before extracting it. A mismatch aborts the install. On a successful install you will see a line like:
+
+```
+Verified SHA-256: aa16b020f28288efc78d97cdebcbfd74ea6602e32b63f9984775b815c722d741
+```
+
+Updating a hash requires a pull request, so the integrity reference lives in git history.
+
+### Verifying a manual download
+
+If you download an archive from the [release page](https://github.com/microsoft/azure-container-apps/releases/tag/aca-cli-v0.1.0-preview), you can verify it yourself against the same pinned value:
+
+**Linux / macOS**
+
+```bash
+sha256sum aca-cli-v0.1.0-preview-linux-x64.tar.gz
+# or, on macOS without coreutils:
+shasum -a 256 aca-cli-v0.1.0-preview-osx-arm64.tar.gz
+```
+
+**Windows (PowerShell)**
+
+```powershell
+Get-FileHash -Algorithm SHA256 aca-cli-v0.1.0-preview-win-x64.zip
+```
+
+Compare the output against the matching line in [`latest-version.txt`](./latest-version.txt).
+
+### Installing an older version
+
+If you pin a version that differs from the one in `latest-version.txt` (via `ACA_VERSION=...` on Linux/macOS or `-Version ...` on Windows), the installer prints a warning and skips the SHA-256 check, since this file only carries the hashes for the currently pinned version.
+
 ## Feedback
 
 This is a public preview. File issues and feedback at <https://github.com/microsoft/azure-container-apps/issues>.

--- a/aca-cli/preview/README.md
+++ b/aca-cli/preview/README.md
@@ -15,22 +15,10 @@ The `aca` CLI is the command-line client for Azure Container Apps Sandboxes, now
 curl -fsSL https://aka.ms/aca-cli-install | sh
 ```
 
-Pin a specific version:
-
-```bash
-curl -fsSL https://aka.ms/aca-cli-install | ACA_VERSION=aca-cli-v0.1.0-preview sh
-```
-
 ### Windows (PowerShell)
 
 ```powershell
 irm https://aka.ms/aca-cli-install-ps | iex
-```
-
-Pin a specific version:
-
-```powershell
-& ([scriptblock]::Create((irm https://aka.ms/aca-cli-install-ps))) -Version aca-cli-v0.1.0-preview
 ```
 
 ## Uninstall
@@ -88,10 +76,6 @@ Get-FileHash -Algorithm SHA256 aca-cli-v0.1.0-preview-win-x64.zip
 ```
 
 Compare the output against the matching line in [`latest-version.txt`](./latest-version.txt).
-
-### Installing an older version
-
-If you pin a version that differs from the one in `latest-version.txt` (via `ACA_VERSION=...` on Linux/macOS or `-Version ...` on Windows), the installer prints a warning and skips the SHA-256 check, since this file only carries the hashes for the currently pinned version.
 
 ## Feedback
 

--- a/aca-cli/preview/install.ps1
+++ b/aca-cli/preview/install.ps1
@@ -35,17 +35,70 @@ function Uninstall-Aca {
     Write-Host "$BinaryName uninstalled successfully."
 }
 
+function Get-Sha256ExpectedHash {
+    param(
+        [Parameter(Mandatory)] [string]$Platform,
+        [Parameter(Mandatory)] [string]$RequestedVersion,
+        [string]$Repo,
+        [string]$Branch
+    )
+
+    $url = "https://raw.githubusercontent.com/$Repo/$Branch/aca-cli/preview/latest-version.txt"
+    try {
+        $content = (Invoke-WebRequest -Uri $url -UseBasicParsing).Content
+    } catch {
+        throw "Could not download $url. Check your network connection."
+    }
+
+    $map = @{}
+    foreach ($line in ($content -split "(`r`n|`n|`r)")) {
+        $trim = $line.Trim()
+        if ($trim -eq '' -or $trim.StartsWith('#')) { continue }
+        $idx = $trim.IndexOf('=')
+        if ($idx -lt 1) { continue }
+        $k = $trim.Substring(0, $idx).Trim()
+        $v = $trim.Substring($idx + 1).Trim()
+        if ($k) { $map[$k] = $v }
+    }
+
+    if (-not $map.ContainsKey('version') -or [string]::IsNullOrWhiteSpace($map['version'])) {
+        throw "latest-version.txt is missing a 'version=' entry."
+    }
+    $pinned = $map['version']
+
+    $effective = $RequestedVersion
+    $verify = $true
+    $expected = $null
+
+    if ($RequestedVersion -eq 'latest' -or $RequestedVersion -eq $pinned) {
+        $effective = $pinned
+        if (-not $map.ContainsKey($Platform)) {
+            throw "latest-version.txt has no SHA-256 entry for platform '$Platform'."
+        }
+        $expected = $map[$Platform].ToLower()
+        if ($expected -notmatch '^[0-9a-f]{64}$') {
+            throw "SHA-256 for '$Platform' in latest-version.txt is not 64 lowercase hex characters."
+        }
+        Write-Host "Pinned version: $effective"
+    } else {
+        $verify = $false
+        Write-Host "Requested version: $RequestedVersion"
+        Write-Host "Pinned version on main: $pinned"
+        Write-Warning "SHA-256 verification skipped because the requested version does not match the pinned version. To get a verified install, omit -Version (or pass -Version $pinned)."
+    }
+
+    return [pscustomobject]@{
+        Version      = $effective
+        ExpectedHash = $expected
+        VerifyHash   = $verify
+    }
+}
+
 function Install-Aca {
     $Platform = "win-x64"
 
-    if ($Version -eq "latest") {
-        # Fetch latest version from version file (no API, no rate limits)
-        $Version = (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/$Repo/$Branch/aca-cli/preview/latest-version.txt" -UseBasicParsing).Content.Trim()
-        if (-not $Version) {
-            throw "Could not determine latest version. Specify manually: -Version aca-cli-v0.1.0-preview"
-        }
-        Write-Host "Latest version: $Version"
-    }
+    $pin = Get-Sha256ExpectedHash -Platform $Platform -RequestedVersion $Version -Repo $Repo -Branch $Branch
+    $Version = $pin.Version
     $Url = "https://github.com/$Repo/releases/download/$Version/$Version-$Platform.zip"
 
     Write-Host "Downloading $BinaryName from $Url..."
@@ -60,7 +113,16 @@ function Install-Aca {
 
     try {
         Invoke-WebRequest -Uri $Url -OutFile $TmpFile -UseBasicParsing
-        
+
+        if ($pin.VerifyHash) {
+            $actual = (Get-FileHash -Algorithm SHA256 $TmpFile).Hash.ToLower()
+            if ($actual -ne $pin.ExpectedHash) {
+                Remove-Item -Force $TmpFile -ErrorAction SilentlyContinue
+                throw "SHA-256 mismatch for $Version-$Platform.zip.`n  expected: $($pin.ExpectedHash)`n  actual:   $actual`nAborting install. The download was not what this release advertises."
+            }
+            Write-Host "Verified SHA-256: $actual"
+        }
+
         if (Test-Path $TmpDir) { Remove-Item -Recurse -Force $TmpDir }
         Expand-Archive -Path $TmpFile -DestinationPath $TmpDir -Force
 

--- a/aca-cli/preview/install.ps1
+++ b/aca-cli/preview/install.ps1
@@ -1,6 +1,5 @@
 # ACA CLI Installer for Windows
 param(
-    [string]$Version = "latest",
     [string]$InstallDir = "$env:USERPROFILE\.aca\bin",
     [switch]$Uninstall
 )
@@ -38,7 +37,6 @@ function Uninstall-Aca {
 function Get-Sha256ExpectedHash {
     param(
         [Parameter(Mandatory)] [string]$Platform,
-        [Parameter(Mandatory)] [string]$RequestedVersion,
         [string]$Repo,
         [string]$Branch
     )
@@ -64,40 +62,25 @@ function Get-Sha256ExpectedHash {
     if (-not $map.ContainsKey('version') -or [string]::IsNullOrWhiteSpace($map['version'])) {
         throw "latest-version.txt is missing a 'version=' entry."
     }
-    $pinned = $map['version']
-
-    $effective = $RequestedVersion
-    $verify = $true
-    $expected = $null
-
-    if ($RequestedVersion -eq 'latest' -or $RequestedVersion -eq $pinned) {
-        $effective = $pinned
-        if (-not $map.ContainsKey($Platform)) {
-            throw "latest-version.txt has no SHA-256 entry for platform '$Platform'."
-        }
-        $expected = $map[$Platform].ToLower()
-        if ($expected -notmatch '^[0-9a-f]{64}$') {
-            throw "SHA-256 for '$Platform' in latest-version.txt is not 64 lowercase hex characters."
-        }
-        Write-Host "Pinned version: $effective"
-    } else {
-        $verify = $false
-        Write-Host "Requested version: $RequestedVersion"
-        Write-Host "Pinned version on main: $pinned"
-        Write-Warning "SHA-256 verification skipped because the requested version does not match the pinned version. To get a verified install, omit -Version (or pass -Version $pinned)."
+    if (-not $map.ContainsKey($Platform)) {
+        throw "latest-version.txt has no SHA-256 entry for platform '$Platform'."
     }
+    $expected = $map[$Platform].ToLower()
+    if ($expected -notmatch '^[0-9a-f]{64}$') {
+        throw "SHA-256 for '$Platform' in latest-version.txt is not 64 lowercase hex characters."
+    }
+    Write-Host "Pinned version: $($map['version'])"
 
     return [pscustomobject]@{
-        Version      = $effective
+        Version      = $map['version']
         ExpectedHash = $expected
-        VerifyHash   = $verify
     }
 }
 
 function Install-Aca {
     $Platform = "win-x64"
 
-    $pin = Get-Sha256ExpectedHash -Platform $Platform -RequestedVersion $Version -Repo $Repo -Branch $Branch
+    $pin = Get-Sha256ExpectedHash -Platform $Platform -Repo $Repo -Branch $Branch
     $Version = $pin.Version
     $Url = "https://github.com/$Repo/releases/download/$Version/$Version-$Platform.zip"
 
@@ -114,14 +97,12 @@ function Install-Aca {
     try {
         Invoke-WebRequest -Uri $Url -OutFile $TmpFile -UseBasicParsing
 
-        if ($pin.VerifyHash) {
-            $actual = (Get-FileHash -Algorithm SHA256 $TmpFile).Hash.ToLower()
-            if ($actual -ne $pin.ExpectedHash) {
-                Remove-Item -Force $TmpFile -ErrorAction SilentlyContinue
-                throw "SHA-256 mismatch for $Version-$Platform.zip.`n  expected: $($pin.ExpectedHash)`n  actual:   $actual`nAborting install. The download was not what this release advertises."
-            }
-            Write-Host "Verified SHA-256: $actual"
+        $actual = (Get-FileHash -Algorithm SHA256 $TmpFile).Hash.ToLower()
+        if ($actual -ne $pin.ExpectedHash) {
+            Remove-Item -Force $TmpFile -ErrorAction SilentlyContinue
+            throw "SHA-256 mismatch for $Version-$Platform.zip.`n  expected: $($pin.ExpectedHash)`n  actual:   $actual`nAborting install. The download was not what this release advertises."
         }
+        Write-Host "Verified SHA-256: $actual"
 
         if (Test-Path $TmpDir) { Remove-Item -Recurse -Force $TmpDir }
         Expand-Archive -Path $TmpFile -DestinationPath $TmpDir -Force

--- a/aca-cli/preview/install.sh
+++ b/aca-cli/preview/install.sh
@@ -36,18 +36,123 @@ detect_platform() {
     PLATFORM="${OS_TAG}-${ARCH_TAG}"
 }
 
-get_download_url() {
-    if [ "$VERSION" = "latest" ]; then
-        # Fetch latest version from version file (no API, no rate limits)
-        VERSION="$(curl -fsSL "https://raw.githubusercontent.com/${REPO}/${BRANCH}/aca-cli/preview/latest-version.txt" | tr -d '[:space:]')"
-        if [ -z "$VERSION" ]; then
-            echo "Error: Could not determine latest version."
-            echo "Specify a version manually: ACA_VERSION=aca-cli-v0.1.0-preview $0"
+# Extract value for "key=..." from latest-version.txt content on stdin.
+# Ignores comment lines (# ...) and trims surrounding whitespace from the value.
+extract_value() {
+    awk -F= -v k="$1" '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*$/ { next }
+        {
+            sub(/^[[:space:]]+/, "", $1)
+            sub(/[[:space:]]+$/, "", $1)
+            if ($1 == k) {
+                sub(/^[^=]*=/, "")
+                sub(/^[[:space:]]+/, "")
+                sub(/[[:space:]]+$/, "")
+                print
+                exit
+            }
+        }'
+}
+
+# True if $1 is a 64-character lowercase hex string.
+is_sha256() {
+    case "$1" in
+        ""|*[!0-9a-f]*) return 1 ;;
+    esac
+    [ "${#1}" -eq 64 ]
+}
+
+# Fetch and parse the pinned latest-version.txt. Sets:
+#   PINNED_VERSION  - the version= line value
+#   EXPECTED_HASH   - the <platform>= line value, or empty when not verifying
+#   VERIFY_HASH     - "yes" when the install must verify the SHA-256, else "no"
+load_version_pin() {
+    VERSION_FILE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/aca-cli/preview/latest-version.txt"
+    VERSION_FILE_CONTENT="$(curl -fsSL "$VERSION_FILE_URL")" || VERSION_FILE_CONTENT=""
+    if [ -z "$VERSION_FILE_CONTENT" ]; then
+        echo "Error: Could not download ${VERSION_FILE_URL}."
+        echo "Check your network connection and try again."
+        exit 1
+    fi
+
+    PINNED_VERSION="$(printf '%s\n' "$VERSION_FILE_CONTENT" | extract_value version)"
+    if [ -z "$PINNED_VERSION" ]; then
+        echo "Error: latest-version.txt is missing a 'version=' entry."
+        exit 1
+    fi
+
+    if [ "$VERSION" = "latest" ] || [ "$VERSION" = "$PINNED_VERSION" ]; then
+        VERSION="$PINNED_VERSION"
+        EXPECTED_HASH="$(printf '%s\n' "$VERSION_FILE_CONTENT" | extract_value "$PLATFORM")"
+        if [ -z "$EXPECTED_HASH" ]; then
+            echo "Error: latest-version.txt has no SHA-256 entry for platform '${PLATFORM}'."
+            echo "This release does not advertise a verified archive for your platform."
             exit 1
         fi
-        echo "Latest version: ${VERSION}"
+        if ! is_sha256 "$EXPECTED_HASH"; then
+            echo "Error: SHA-256 for '${PLATFORM}' in latest-version.txt is not 64 lowercase hex characters."
+            exit 1
+        fi
+        VERIFY_HASH="yes"
+        echo "Pinned version: ${VERSION}"
+    else
+        # User asked for a version different from the one pinned in main.
+        # We can't verify older/newer tags from this file, so install but warn.
+        EXPECTED_HASH=""
+        VERIFY_HASH="no"
+        echo "Requested version: ${VERSION}"
+        echo "Pinned version on main: ${PINNED_VERSION}"
+        echo "WARNING: SHA-256 verification skipped because the requested version does not match the pinned version."
+        echo "         To get a verified install, run without ACA_VERSION (or set ACA_VERSION=${PINNED_VERSION})."
     fi
+}
+
+get_download_url() {
+    load_version_pin
     URL="https://github.com/${REPO}/releases/download/${VERSION}/${VERSION}-${PLATFORM}.tar.gz"
+}
+
+# Compute the SHA-256 of $1 using whichever tool is available; print to stdout.
+compute_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        echo ""
+        return 1
+    fi
+}
+
+# tolower without depending on bash; works in dash/ash.
+to_lower() {
+    printf '%s' "$1" | tr 'A-Z' 'a-z'
+}
+
+verify_archive() {
+    archive="$1"
+    if [ "$VERIFY_HASH" != "yes" ]; then
+        return 0
+    fi
+    actual="$(compute_sha256 "$archive")"
+    rc=$?
+    if [ $rc -ne 0 ] || [ -z "$actual" ]; then
+        echo "Error: SHA-256 verification is required but neither 'sha256sum' nor 'shasum -a 256' is available."
+        echo "On Alpine/busybox, install coreutils:  apk add --no-cache coreutils"
+        exit 1
+    fi
+    actual="$(to_lower "$actual")"
+    expected="$(to_lower "$EXPECTED_HASH")"
+    if [ "$actual" != "$expected" ]; then
+        echo "Error: SHA-256 mismatch for ${VERSION}-${PLATFORM}.tar.gz."
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+        echo "Aborting install. The download was not what this release advertises."
+        rm -f "$archive"
+        exit 1
+    fi
+    echo "Verified SHA-256: ${actual}"
 }
 
 uninstall() {
@@ -90,6 +195,7 @@ install() {
     trap 'rm -rf "$TMP_DIR"' EXIT
 
     curl -fsSL "$URL" -o "${TMP_DIR}/${BINARY_NAME}.tar.gz"
+    verify_archive "${TMP_DIR}/${BINARY_NAME}.tar.gz"
     tar -xzf "${TMP_DIR}/${BINARY_NAME}.tar.gz" -C "$TMP_DIR"
 
     # Install to INSTALL_DIR (try sudo if needed)

--- a/aca-cli/preview/install.sh
+++ b/aca-cli/preview/install.sh
@@ -6,9 +6,6 @@ BRANCH="main"
 BINARY_NAME="aca"
 INSTALL_DIR="/usr/local/bin"
 
-# Allow overriding version; default to latest
-VERSION="${ACA_VERSION:-latest}"
-
 detect_platform() {
     OS="$(uname -s)"
     ARCH="$(uname -m)"
@@ -64,9 +61,8 @@ is_sha256() {
 }
 
 # Fetch and parse the pinned latest-version.txt. Sets:
-#   PINNED_VERSION  - the version= line value
-#   EXPECTED_HASH   - the <platform>= line value, or empty when not verifying
-#   VERIFY_HASH     - "yes" when the install must verify the SHA-256, else "no"
+#   VERSION         - the version= line value
+#   EXPECTED_HASH   - the <platform>= line value, validated as 64-char hex
 load_version_pin() {
     VERSION_FILE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}/aca-cli/preview/latest-version.txt"
     VERSION_FILE_CONTENT="$(curl -fsSL "$VERSION_FILE_URL")" || VERSION_FILE_CONTENT=""
@@ -76,36 +72,23 @@ load_version_pin() {
         exit 1
     fi
 
-    PINNED_VERSION="$(printf '%s\n' "$VERSION_FILE_CONTENT" | extract_value version)"
-    if [ -z "$PINNED_VERSION" ]; then
+    VERSION="$(printf '%s\n' "$VERSION_FILE_CONTENT" | extract_value version)"
+    if [ -z "$VERSION" ]; then
         echo "Error: latest-version.txt is missing a 'version=' entry."
         exit 1
     fi
 
-    if [ "$VERSION" = "latest" ] || [ "$VERSION" = "$PINNED_VERSION" ]; then
-        VERSION="$PINNED_VERSION"
-        EXPECTED_HASH="$(printf '%s\n' "$VERSION_FILE_CONTENT" | extract_value "$PLATFORM")"
-        if [ -z "$EXPECTED_HASH" ]; then
-            echo "Error: latest-version.txt has no SHA-256 entry for platform '${PLATFORM}'."
-            echo "This release does not advertise a verified archive for your platform."
-            exit 1
-        fi
-        if ! is_sha256 "$EXPECTED_HASH"; then
-            echo "Error: SHA-256 for '${PLATFORM}' in latest-version.txt is not 64 lowercase hex characters."
-            exit 1
-        fi
-        VERIFY_HASH="yes"
-        echo "Pinned version: ${VERSION}"
-    else
-        # User asked for a version different from the one pinned in main.
-        # We can't verify older/newer tags from this file, so install but warn.
-        EXPECTED_HASH=""
-        VERIFY_HASH="no"
-        echo "Requested version: ${VERSION}"
-        echo "Pinned version on main: ${PINNED_VERSION}"
-        echo "WARNING: SHA-256 verification skipped because the requested version does not match the pinned version."
-        echo "         To get a verified install, run without ACA_VERSION (or set ACA_VERSION=${PINNED_VERSION})."
+    EXPECTED_HASH="$(printf '%s\n' "$VERSION_FILE_CONTENT" | extract_value "$PLATFORM")"
+    if [ -z "$EXPECTED_HASH" ]; then
+        echo "Error: latest-version.txt has no SHA-256 entry for platform '${PLATFORM}'."
+        echo "This release does not advertise a verified archive for your platform."
+        exit 1
     fi
+    if ! is_sha256 "$EXPECTED_HASH"; then
+        echo "Error: SHA-256 for '${PLATFORM}' in latest-version.txt is not 64 lowercase hex characters."
+        exit 1
+    fi
+    echo "Pinned version: ${VERSION}"
 }
 
 get_download_url() {
@@ -132,9 +115,6 @@ to_lower() {
 
 verify_archive() {
     archive="$1"
-    if [ "$VERIFY_HASH" != "yes" ]; then
-        return 0
-    fi
     actual="$(compute_sha256 "$archive")"
     rc=$?
     if [ $rc -ne 0 ] || [ -z "$actual" ]; then

--- a/aca-cli/preview/latest-version.txt
+++ b/aca-cli/preview/latest-version.txt
@@ -1,1 +1,10 @@
-aca-cli-v0.1.0-preview
+# ACA CLI release pin.
+# install.sh and install.ps1 read this file to determine the version
+# AND the expected SHA-256 of each platform archive. A mismatch aborts
+# the install. Lines beginning with # and blank lines are ignored.
+# Updating a hash requires a PR review.
+
+version=aca-cli-v0.1.0-preview
+linux-x64=aa16b020f28288efc78d97cdebcbfd74ea6602e32b63f9984775b815c722d741
+osx-arm64=362fa2da370a996660d23ffae9f2eca4e28a32e501a4b8818297cb066eb5f6dc
+win-x64=62dcf2cfc67443d361ea43460a2197736c3a3ad86b377a3d9d542791cec2ab5d


### PR DESCRIPTION
## Summary

Pin the SHA-256 of each platform archive in `aca-cli/preview/latest-version.txt` and have `install.sh` / `install.ps1` verify the downloaded archive before extracting it. A hash mismatch aborts the install with no files written.

This means a tampered or corrupted download is rejected by the installer, and the integrity reference lives in git history (changing a hash requires a PR review) rather than alongside the asset on the GitHub Release.

## File format

`aca-cli/preview/latest-version.txt` changes from a bare version line to `key=value`:

```
version=aca-cli-v0.1.0-preview
linux-x64=aa16b020f28288efc78d97cdebcbfd74ea6602e32b63f9984775b815c722d741
osx-arm64=362fa2da370a996660d23ffae9f2eca4e28a32e501a4b8818297cb066eb5f6dc
win-x64=62dcf2cfc67443d361ea43460a2197736c3a3ad86b377a3d9d542791cec2ab5d
```

- `#` comments and blank lines are ignored.
- Hashes must be 64 lowercase hex characters; anything else is rejected.
- The 3 hashes above match the archives currently published on the `aca-cli-v0.1.0-preview` release (built from `msazure/One` build `166213655` and re-uploaded immediately before this PR).

## Installer behavior

| Scenario | `install.sh` | `install.ps1` |
| --- | --- | --- |
| Default (no override) | parses file, verifies via `sha256sum` or `shasum -a 256` | parses file, verifies via `Get-FileHash -Algorithm SHA256` |
| Override matches `version=` | verifies (same path as default) | verifies (same path as default) |
| Override differs from `version=` | prints warning, **skips** verify (no pinned hash for older/newer tags) | prints warning, **skips** verify |
| `sha256sum` / `shasum` missing (Alpine/busybox) | aborts with actionable error: `apk add --no-cache coreutils` | n/a |
| Hash mismatch | deletes tmp file, prints expected vs actual, `exit 1` before any `tar -x` | deletes tmp file, `throw` before any `Expand-Archive` |
| Missing platform key or malformed hash | aborts with explicit error | aborts with explicit error |

## Local testing

- `install.sh` parser/verify functions tested in WSL Ubuntu (extract, hex validation, `sha256sum`+`shasum` fallback, busybox missing-tool case, mismatch deletes tmp).
- `install.ps1` `Get-Sha256ExpectedHash` tested with mocked `Invoke-WebRequest` (latest, override-equals-pinned, override-differs, missing version, missing platform, malformed hex, uppercase normalization, CRLF).
- End-to-end against the published release for both scripts:
  - default install → installs and prints `Verified SHA-256: <hash>`
  - tampered expected-hash → aborts, no binary written
  - override to a non-existent tag → warns + skips verify (404 from GitHub as expected)

## Future drops

After this merges, every release refresh must follow:

1. Upload the 3 new archives to the release.
2. Open a PR bumping `version=` and the 3 hashes in `latest-version.txt`.
3. Merge.

Users running the new installer between step 1 and step 3 will see a hash mismatch (bounded by PR merge time). The release-refresh runbook is being updated separately to document this ordering.