### PR TITLE
fix path on bash shell

### DIFF
--- a/aca-cli/preview/install.sh
+++ b/aca-cli/preview/install.sh
@@ -4,7 +4,7 @@ set -e
 REPO="microsoft/azure-container-apps"
 BRANCH="main"
 BINARY_NAME="aca"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 detect_platform() {
     OS="$(uname -s)"


### PR DESCRIPTION
to accept alt bin path -- using 

eg.

```
curl -fsSL https://aka.ms/aca-cli-install | INSTALL_DIR=$HOME/bin sh
```