### PR TITLE
docs: add ACA Jobs orchestrator template collection

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -14,6 +14,15 @@ To use these templates, follow the instructions provided in each template's
 README file. These templates are meant to be used as a starting point for 
 your own configurations. You can customize them to fit your specific requirements.
 
+## Community template collections
+
+- [Bring Your Own Orchestrator to Azure Container Apps Jobs](https://github.com/hetvip2/aca-jobs-orchestrator-templates)
+	compares community-maintained integration templates for using Airflow, Argo
+	Workflows, Camunda 8, Conductor, Dagster, Dapr Workflow, Azure Data Factory and
+	Fabric, Durable Functions, Logic Apps Standard, n8n, Prefect, or Temporal as an
+	orchestrator for Azure Container Apps Jobs. Each linked repository includes its
+	own deployment instructions, validation scope, and documented limitations.
+
 ## Disclaimer
 Please note that these templates are for reference purposes only and are not 
 intended for production environments. They are provided "as-is" without any 


### PR DESCRIPTION
## Summary

Adds a community template collection for connecting existing orchestrators to Azure Container Apps Jobs.

The linked catalog compares 13 templates covering Airflow, Argo Workflows, Camunda 8, Conductor, Dagster, Dapr Workflow, Azure Data Factory and Fabric, Durable Functions, Logic Apps Standard, n8n, Prefect, and Temporal. Each implementation remains in its own repository so its tests, native runtime evidence, limitations, and release history can be maintained independently.

## Why this approach

The current `templates/` directory contains checked-in IaC samples and does not define an external template registry. This draft proposes a small, clearly labeled `Community template collections` section rather than vendoring 13 independently maintained repositories in one PR.

Maintainer feedback is welcome on whether this linked collection is appropriate here or whether selected templates should instead be proposed individually as self-contained directories.

## Validation

- Confirmed the collection and all 13 linked repositories are public.
- Confirmed the catalog identifies each orchestrator's intended use case.
- Confirmed per-template validation scope and limitations are documented, including the Dapr preview architecture and Fabric native-validation status.
- Ran `git diff --check`.

## Ownership and support

These are community-maintained reference templates and are not represented as Microsoft-supported artifacts. The existing templates disclaimer continues to apply.